### PR TITLE
Added check to avoid floating point error during reconstruction of pa…

### DIFF
--- a/SEMBase/SEMBase.C
+++ b/SEMBase/SEMBase.C
@@ -167,7 +167,14 @@ void SEMBase::initilise()
 
 
     //set averaging window size
-    avgWindow_ = cmptMax( max(sigma_) )/mag(UBulk_) * 5.0;
+    if ( mag(cmptMax( max(sigma_) )) > ROOTVGREAT && mag(UBulk_) < SMALL)
+    {
+        avgWindow_ = cmptMax( max(sigma_) );
+    }
+    else
+    {
+        avgWindow_ = cmptMax( max(sigma_) )/mag(UBulk_) * 5.0;
+    }
     reduce( avgWindow_, maxOp<scalar>() );
 }
 


### PR DESCRIPTION
…rallel runs

PROBLEM:
When the BC is used on parallel, the reconstruction calls initilise() for every processor. When the processor has no eddies in it, smptMax(max(sigma_))=-GREAT and mag(UBulk_)=0. Then the calculation of avgWindow throws floating point exception.
SOLUTION:
The values of sigma_ and UBulk_ are checked before the operation, returning the appropriate value in each case.